### PR TITLE
Backwards compatible fix for `master`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine
 ARG TOWER_CLI_VERSION="0.4"
 
 # Install Tower CLI
-RUN apk add --no-cache curl ca-certificates
+RUN apk add --no-cache curl ca-certificates jq
 RUN curl -L https://github.com/seqeralabs/tower-cli/releases/download/v${TOWER_CLI_VERSION}/tw-${TOWER_CLI_VERSION}-linux-x86_64 > tw
 RUN chmod +x ./tw
 RUN mv tw /usr/local/bin/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 **A GitHub Action to launch a workflow using [Nextflow Tower](https://tower.nf) - <https://tower.nf>.**
 
+## NB: This `master` branch is onlyfor backwards compatability
+
+Because version 2.0 of this action broke backwards compatability, and nf-core pipelines at the time
+are set up to use `@master`, this branch contains workarounds to ensure that they keep working.
+
+Going forward, please use `@2` for the latest version under the v2 major release.
+
+If writing a new action, please do not use this `master` branch. Instead see `main` for the latest stable code.
+
 ## Example usage
 
 ### Minimal example
@@ -17,7 +26,7 @@ jobs:
   run-tower:
     runs-on: ubuntu-latest
     steps:
-      - uses: nf-core/tower-action@master
+      - uses: nf-core/tower-action@2
         # Use repository secrets for sensitive fields
         with:
           access_token: ${{ secrets.TOWER_ACCESS_TOKEN }}

--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ runs:
   env:
     TOWER_WORKSPACE_ID: ${{ inputs.workspace_id }}
     TOWER_API_ENDPOINT: ${{ inputs.api_endpoint }}
-    TOWER_BEARER_TOKEN: ${{ inputs.bearer_token }}
+    TOWER_ACCESS_TOKEN: ${{ inputs.bearer_token }}
     TOWER_COMPUTE_ENV: ${{ inputs.compute_env }}
     PIPELINE: ${{ inputs.pipeline }}
     REVISION: ${{ inputs.revision }}

--- a/action.yml
+++ b/action.yml
@@ -8,12 +8,12 @@ branding:
   color: 'purple'
 
 inputs:
-  access_token:
+  bearer_token:
     description: Nextflow Tower access token
     required: true
   compute_env:
     description: Nextflow Tower compute env
-    required: false
+    required: true
   workspace_id:
     description: Nextflow Tower workspace ID
     required: false
@@ -35,9 +35,11 @@ inputs:
   parameters:
     description: Pipeline parameters
     required: false
+    default: '{}'
   profiles:
     description: Nextflow config profiles
     required: false
+    default: '[]'
 
 runs:
   using: 'docker'
@@ -45,7 +47,7 @@ runs:
   env:
     TOWER_WORKSPACE_ID: ${{ inputs.workspace_id }}
     TOWER_API_ENDPOINT: ${{ inputs.api_endpoint }}
-    TOWER_ACCESS_TOKEN: ${{ inputs.access_token }}
+    TOWER_BEARER_TOKEN: ${{ inputs.bearer_token }}
     TOWER_COMPUTE_ENV: ${{ inputs.compute_env }}
     PIPELINE: ${{ inputs.pipeline }}
     REVISION: ${{ inputs.revision }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,7 @@ tw info
 echo $PARAMETERS > params.json
 
 # Hack to convert profiles JSON to csv
-echo $CONFIG_PROFILES | jq -r '. | @csv' | sed 's/"//g'
+CONFIG_PROFILES_CSV=$(echo $CONFIG_PROFILES | jq -r '. | @csv' | sed 's/"//g')
 
 # Launch the pipeline
 tw launch $PIPELINE \
@@ -15,4 +15,4 @@ tw launch $PIPELINE \
     ${WORKDIR:+"--work-dir=$WORKDIR"} \
     ${TOWER_COMPUTE_ENV:+"--compute-env=$TOWER_COMPUTE_ENV"} \
     ${REVISION:+"--revision=$REVISION"} \
-    ${CONFIG_PROFILES:+"--profile=$CONFIG_PROFILES"}
+    ${CONFIG_PROFILES_CSV:+"--profile=$CONFIG_PROFILES_CSV"}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,6 +6,9 @@ tw info
 # Print the params input to a file
 echo $PARAMETERS > params.json
 
+# Hack to convert profiles JSON to csv
+echo $CONFIG_PROFILES | jq -r '. | @csv' | sed 's/"//g'
+
 # Launch the pipeline
 tw launch $PIPELINE \
     --params=params.json \


### PR DESCRIPTION
PR https://github.com/nf-core/tower-action/pull/3 rewrote this action to use the new Tower CLI, which is much nicer. However, that involved making some changes that were not backwards compatible.

This PR is intended only as a short-term bandage to provide backwards compatibility for existing pipelines running this action on `master` branch. It's needed as the previous code using the API directly stopped working.

After a while, once we are sure that most pipelines have updated to the template change that will pin the newer v2 version of this action, we can remove this branch. I will set the new `main` branch to be the default for the repo, this will contain the clean v2 release.

Workaround code tested here: https://github.com/nf-core/smrnaseq/runs/4257698578?check_suite_focus=true