### PR TITLE
Add pre-run script as an option for the Tower CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # nf-core/tower-action: Changelog
 
+## [[v2.1](https://github.com/nf-core/tower-action/releases/tag/v2.1)] - 2021-11-30
+
+Add option to pass pre-run script to Tower CLI.
+
 ## [[v2.0](https://github.com/nf-core/tower-action/releases/tag/v2.0)] - 2021-11-19
 
 A complete rewrite of the action to use the new [Nextflow Tower CLI](https://github.com/seqeralabs/tower-cli)

--- a/README.md
+++ b/README.md
@@ -159,16 +159,11 @@ Pre-run script executed before pipeline launch. This would be particularly usefu
 ```yaml
 jobs:
   run-tower:
-    name: Launch on Nextflow Tower
-    # Don't try to run on forked repos
-    if: github.repository == 'YOUR_USERNAME/REPO'
-    runs-on: ubuntu-latest
     steps:
       - uses: nf-core/tower-action@v2
         with:
-          <TRUNCATED>
           pre_run_script: 'export NXF_VER=21.10.3'
-          <TRUNCATED>
+          # Truncated..
 ```
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -150,6 +150,12 @@ These should be supplied as a valid JSON object, quoted as a string in your GitH
 
 Pipeline config profiles to use. Should be comma separated without spaces.
 
+### `pre_run_script`
+
+**[Optional]** Pre-run script before launch.
+
+Pre-run script executed before pipeline launch.
+
 ## Credits
 
 This GitHub Action was written by Phil Ewels ([@ewels](https://github.com/ewels)), with help from and based on earlier work by Gisela Gabernet ([@ggabernet](https://github.com/ggabernet)).

--- a/README.md
+++ b/README.md
@@ -154,7 +154,22 @@ Pipeline config profiles to use. Should be comma separated without spaces.
 
 **[Optional]** Pre-run script before launch.
 
-Pre-run script executed before pipeline launch.
+Pre-run script executed before pipeline launch. This would be particularly useful if you wanted to use a different version of Nextflow than the default available in Tower. You can set this in the pipeline Github Actions:
+
+```yaml
+jobs:
+  run-tower:
+    name: Launch on Nextflow Tower
+    # Don't try to run on forked repos
+    if: github.repository == 'YOUR_USERNAME/REPO'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: nf-core/tower-action@v2
+        with:
+          <TRUNCATED>
+          pre_run_script: 'export NXF_VER=21.10.3'
+          <TRUNCATED>
+```
 
 ## Credits
 

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,9 @@ inputs:
   profiles:
     description: Nextflow config profiles
     required: false
+  pre_run_script:
+    description: Pre-run script before launch
+    required: false
 
 runs:
   using: 'docker'
@@ -52,3 +55,4 @@ runs:
     WORKDIR: ${{ inputs.workdir }}
     PARAMETERS: ${{ toJson(fromJson(inputs.parameters)) }}
     CONFIG_PROFILES: ${{ inputs.profiles }}
+    PRE_RUN_SCRIPT: ${{ inputs.pre_run_script }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,4 +12,5 @@ tw launch $PIPELINE \
     ${WORKDIR:+"--work-dir=$WORKDIR"} \
     ${TOWER_COMPUTE_ENV:+"--compute-env=$TOWER_COMPUTE_ENV"} \
     ${REVISION:+"--revision=$REVISION"} \
-    ${CONFIG_PROFILES:+"--profile=$CONFIG_PROFILES"}
+    ${CONFIG_PROFILES:+"--profile=$CONFIG_PROFILES"} \
+    ${PRE_RUN_SCRIPT:+"--pre-run=$PRE_RUN_SCRIPT"}


### PR DESCRIPTION
This would be particularly useful if you need to export particular versions of NF to be used on Tower. There is no default set but it can be overriden via the pipeline Actions if required.