### PR TITLE
Add Nextflow config option to Tower Action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # nf-core/tower-action: Changelog
 
+## [[v2.2](https://github.com/nf-core/tower-action/releases/tag/v2.2)] - 2022-01-10
+
+Add option to pass nextflow config to Tower CLI.
+
 ## [[v2.1](https://github.com/nf-core/tower-action/releases/tag/v2.1)] - 2021-11-30
 
 Add option to pass pre-run script to Tower CLI.

--- a/README.md
+++ b/README.md
@@ -162,7 +162,9 @@ jobs:
     steps:
       - uses: nf-core/tower-action@v2
         with:
-          nextflow_config: 'process.errorStrategy = 'retry'\nprocess.maxRetries = 3'
+          nextflow_config: |
+            process.errorStrategy = 'retry'
+            process.maxRetries = 3
           # Truncated..
 ```
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,22 @@ These should be supplied as a valid JSON object, quoted as a string in your GitH
 
 Pipeline config profiles to use. Should be comma separated without spaces.
 
+### `nextflow_config`
+
+**[Optional]** Nextflow config options.
+
+Useful to pass custom Nextflow config options to the `tw launch` command e.g.
+
+```yaml
+jobs:
+  run-tower:
+    steps:
+      - uses: nf-core/tower-action@v2
+        with:
+          nextflow_config: 'process.errorStrategy = 'retry'\nprocess.maxRetries = 3'
+          # Truncated..
+```
+
 ### `pre_run_script`
 
 **[Optional]** Pre-run script before launch.

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,9 @@ inputs:
   profiles:
     description: Nextflow config profiles
     required: false
+  nextflow_config:
+    description: Nextflow config options
+    required: false
   pre_run_script:
     description: Pre-run script before launch
     required: false
@@ -55,4 +58,5 @@ runs:
     WORKDIR: ${{ inputs.workdir }}
     PARAMETERS: ${{ toJson(fromJson(inputs.parameters)) }}
     CONFIG_PROFILES: ${{ inputs.profiles }}
+    NEXTFLOW_CONFIG: ${{ inputs.nextflow_config }}
     PRE_RUN_SCRIPT: ${{ inputs.pre_run_script }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,11 +9,17 @@ echo -e $PARAMETERS > params.json
 # Print the pre-run script to a file
 echo -e $PRE_RUN_SCRIPT > pre_run.sh
 
+# Print the nextflow config  to a file
+echo -e $NEXTFLOW_CONFIG > nextflow.config
+
 # Launch the pipeline
-tw launch $PIPELINE \
+tw \
+    launch \
+    $PIPELINE \
     --params=params.json \
     ${WORKDIR:+"--work-dir=$WORKDIR"} \
     ${TOWER_COMPUTE_ENV:+"--compute-env=$TOWER_COMPUTE_ENV"} \
     ${REVISION:+"--revision=$REVISION"} \
     ${CONFIG_PROFILES:+"--profile=$CONFIG_PROFILES"} \
-    ${PRE_RUN_SCRIPT:+"--pre-run=pre_run.sh"}
+    ${PRE_RUN_SCRIPT:+"--pre-run=pre_run.sh"} \
+    ${NEXTFLOW_CONFIG:+"--config=nextflow.config"}


### PR DESCRIPTION
We should add an automatic error retry strategy to the AWS megatests since we are using SPOT instances by default. I noticed a few failures with the latest version of the rnaseq pipeline recently that were resolved after using the Nextflow config settings below in Tower:

```
process.errorStrategy = 'retry'
process.maxRetries = 3
```

The changes in this PR allow us to pass these options to the `tw launch` command in the AWS actions we have in the pipeline template (and generically).

**PS: The release date in the CHANGELOG will need to be changed**