### PR TITLE
Bump Tower CLI version

### DIFF
--- a/.github/workflows/update-tag.yml
+++ b/.github/workflows/update-tag.yml
@@ -1,0 +1,13 @@
+name: Update major version tag
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  update-major-ver:
+    name: Update major version tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: nowactions/update-majorver@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # nf-core/tower-action: Changelog
 
+## [[v3.1.0](https://github.com/nf-core/tower-action/releases/tag/v3.1.0)] - 2022-06-26
+
+* Bumped tower-cli version `0.5` -> `0.6.2`
+
 ## [[v3.0.1](https://github.com/nf-core/tower-action/releases/tag/v3.0.1)] - 2022-03-23
 
 * Bugfix: should be `--params-file` and not `--params`

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine
 
-ARG TOWER_CLI_VERSION="0.5"
+ARG TOWER_CLI_VERSION="0.6.2"
 
 # Install Tower CLI
 RUN apk add --no-cache curl ca-certificates


### PR DESCRIPTION
New release 3.1.0 to update the Tower CLI to version 0.6.2